### PR TITLE
WIP: DO NOT MERGE Fixed whitespace issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /.phpunit.result.cache
 /clover.xml
 /coveralls-upload.json

--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -428,9 +428,24 @@ abstract class AbstractSql implements SqlInterface
         if ($column === null) {
             return 'NULL';
         }
+
+        /**
+         * Fix for spaces on column names.
+         * @see https://github.com/laminas/laminas-db/issues/84
+         */
+        $startsWithNumber = preg_match('/^[0-9]+/', $column);
+        $hasSpaceOrDash = preg_match('/^(.+)(\s|-)+(.+)$/i', $column);
+        if ($isIdentifier) {
+            if ($startsWithNumber || $hasSpaceOrDash) {
+                $column = $platform->quoteIdentifier($column);
+            } else {
+                $column = $platform->quoteIdentifierInFragment($column);
+            }
+        }
+
         return $isIdentifier
-                ? $fromTable . $platform->quoteIdentifierInFragment($column)
-                : $platform->quoteValue($column);
+            ? $fromTable . $column
+            : $platform->quoteValue($column);
     }
 
     /**


### PR DESCRIPTION
Issue with whitespace on column names like "Name 2". This issue will split this "Name 2" in two separate Names like [Name] [2] instead of [Name 2].
This fix will solve these issues.

Issue with bugfix on laminas/laminas-db:
https://github.com/laminas/laminas-db/issues/84